### PR TITLE
Fix salt generation when mcrypt is not installed

### DIFF
--- a/tmarsteel/dprng/DPRNG.php
+++ b/tmarsteel/dprng/DPRNG.php
@@ -30,25 +30,25 @@ class DPRNG
         0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
         0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16
     );
-    
+
     /**
      * The initial state; simply stored for getInitialSalt
      * @var int
      */
     private $initialState = null;
-    
+
     /**
      * The current state; the salt is the initial state
      * @var int
      */
     private $state = 0;
-    
+
     /**
      * The counter. Is XORed with the state prior to each generation step.
      * @var int
      */
     private $counter = 0;
-    
+
     /**
      * @param int $salt The 28bit salt / initial state to use. If omitted, one is
      * obtained through mcrypt_create_iv if available, rand() otherwise.
@@ -62,16 +62,19 @@ class DPRNG
                 $rand = mcrypt_create_iv(4);
                 $salt = (ord($rand[0]) << 20) | (ord($rand[1]) << 12) | (ord($rand[2]) << 4) | (ord($rand[3]) & 0xF);
             }
+            else if (function_exists("random_int")) {
+                $salt = random_int(0, 0xFFFFFFF);
+            }
             else
             {
-                $salt = rand(0, 0xFFFFFFFF);
+                $salt = rand(0, 0xFFFFFFF);
             }
         }
-        
+
         $this->initialState = $salt & 0xFFFFFFF;
         $this->state = $this->initialState;
     }
-    
+
 	/**
 	 * Returns a pseudo-random, uniformly distributed <code>double</code> value in
 	 * the range 0 inclusive to 1 exclusive.
@@ -80,8 +83,8 @@ class DPRNG
 	public function next() {
 		return ((float) $this->nextInt(0, 0xFFFFFFF)) / ((float) 0xFFFFFFF);
 	}
-	
-	/**	
+
+	/**
 	 * Returns a pseudo-random uniformly distributed <code>double</code> value in
 	 * the range <code>$min</code> inclusive to <code>$max</code> inclusive.
 	 * @param double $min
@@ -94,10 +97,10 @@ class DPRNG
 		{
 			return $this->nextDouble($max, $min);
 		}
-		
+
 		return $min + $this->next() * ($max - $min);
 	}
-	
+
     /**
      * Returns a pseudo-random uniformly distributed <code>int<code> value in
 	 * the range <code>$min</code> inclusive to <code>$max</code> <b>inclusive</b>.
@@ -115,9 +118,9 @@ class DPRNG
         {
             return $min;
         }
-        
+
         $rangeSize = $max - $min;
-        
+
         $nRequiredBits = min(ceil(log($rangeSize, 2)), 32);
         $result = null;
 
@@ -125,7 +128,7 @@ class DPRNG
         {
             $additionalBits = 32 - $nRequiredBits;
             $mask = pow(2, $additionalBits) - 1;
-            
+
             $result = (($this->advance() << $additionalBits) | ($this->advance() & $mask));
         }
         else
@@ -133,14 +136,14 @@ class DPRNG
             $mask = pow(2, $nRequiredBits) - 1;
             $result = ($this->advance() & $mask);
         }
-        
+
         // for ranges that are not a 2-complement, larger values than $max may
         // be in $result => reduce to the range by dividing by 2
         while ($min + $result > $max) $result = floor($result / 2);
-        
+
         return $result;
     }
-	
+
 	/**
 	 * Returns an array of length <code>$n</code> with each element being
 	 * a pseudo-random and uniformly distributed integer in the range 0 to 255 inclusive.
@@ -153,10 +156,10 @@ class DPRNG
 		{
 			$ar []= $this->nextInt(0, 255);
 		}
-		
+
 		return $ar;
 	}
-    
+
     /**
      * Advances the inner state and returns random 28 bits.
 	 * @return int


### PR DESCRIPTION
0xFFFFFFFF is a float in PHP because it exceeds signed int. rand() doesn't accept floats, so just always returns 0.